### PR TITLE
Implement real-time upstream statistics with LOG_PHASE handler

### DIFF
--- a/config
+++ b/config
@@ -5,7 +5,7 @@ if test -n "$ngx_module_link"; then
     ngx_module_name=ngx_http_vts_module
     ngx_module_incs=
     ngx_module_deps=
-    ngx_module_srcs=
+    ngx_module_srcs="$ngx_addon_dir/src/ngx_http_vts_module.c $ngx_addon_dir/src/ngx_vts_wrapper.c"
     ngx_module_libs="$ngx_addon_dir/target/release/libngx_vts_rust.so"
     . auto/module
 else

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,51 @@ pub extern "C" fn vts_is_upstream_stats_enabled() -> bool {
     VTS_MANAGER.read().is_ok()
 }
 
+/// Get VTS status content for C integration
+/// Returns a pointer to a freshly generated status content string
+/// 
+/// # Safety
+/// 
+/// The returned pointer is valid until the next call to this function.
+/// The caller must not free the returned pointer.
+#[no_mangle]
+pub extern "C" fn ngx_http_vts_get_status() -> *const c_char {
+    use std::sync::Mutex;
+    
+    static STATUS_CACHE: Mutex<Option<std::ffi::CString>> = Mutex::new(None);
+    
+    let status_content = generate_vts_status_content();
+    let c_string = std::ffi::CString::new(status_content)
+        .unwrap_or_else(|_| std::ffi::CString::new("Failed to generate VTS status").unwrap());
+    
+    // Update cache with fresh content
+    if let Ok(mut cache) = STATUS_CACHE.lock() {
+        *cache = Some(c_string);
+        cache.as_ref().unwrap().as_ptr()
+    } else {
+        // Fallback if mutex is poisoned
+        static FALLBACK: &[u8] = b"VTS Status: Error\0";
+        FALLBACK.as_ptr() as *const c_char
+    }
+}
+
+/// External initialization function for nginx module integration
+/// This function is called from the C wrapper during module initialization
+///
+/// # Safety
+///
+/// This function is safe to call from C code as it handles the null pointer case
+/// and doesn't dereference the configuration pointer directly.
+#[no_mangle]
+pub unsafe extern "C" fn ngx_http_vts_init_rust_module(_cf: *mut ngx_conf_t) -> ngx_int_t {
+    // Initialize upstream zones
+    if initialize_upstream_zones_from_config(_cf).is_err() {
+        return NGX_ERROR as ngx_int_t;
+    }
+
+    NGX_OK as ngx_int_t
+}
+
 /// VTS main configuration structure (simplified for now)
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -793,18 +838,20 @@ unsafe fn initialize_upstream_zones_from_config(_cf: *mut ngx_conf_t) -> Result<
 }
 
 /// Register LOG_PHASE handler for real-time request statistics collection
-/// Based on C implementation: cmcf->phases[NGX_HTTP_LOG_PHASE].handlers
-/// TEMPORARILY DISABLED: Direct FFI access causing segfault, using external C API instead
+///
+/// NOTE: Due to nginx-rust FFI limitations, this function exports the necessary
+/// hooks for external integration. The actual LOG_PHASE registration should be
+/// done by a companion C module that calls vts_track_upstream_request().
 unsafe fn register_log_phase_handler(_cf: *mut ngx_conf_t) -> Result<(), &'static str> {
-    // NOTE: Direct nginx FFI registration is disabled due to compatibility issues
-    // The LOG_PHASE handler integration should be done via external C code
-    // that calls vts_track_upstream_request() function.
+    // For now, we rely on external C code to register the LOG_PHASE handler
+    // The external handler should call vts_track_upstream_request() for each upstream request
     //
-    // For manual integration, nginx administrators can add calls to:
-    // vts_track_upstream_request(upstream_name, server_addr, request_time,
-    //                           upstream_time, bytes_sent, bytes_received, status)
+    // Future implementations can use direct nginx FFI once compatibility issues are resolved
     //
-    // This provides the same functionality without FFI compatibility issues.
+    // Alternative approaches:
+    // 1. nginx logging module extension that calls our C API
+    // 2. Custom nginx module that wraps our Rust functionality
+    // 3. Direct FFI integration when nginx-rust supports it
 
     Ok(())
 }

--- a/src/ngx_http_vts_module.c
+++ b/src/ngx_http_vts_module.c
@@ -1,0 +1,227 @@
+/*
+ * nginx VTS module main definition
+ * 
+ * This file defines the nginx module structure and integrates with
+ * the Rust implementation via the C wrapper.
+ */
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+// Forward declarations from wrapper
+extern ngx_int_t ngx_http_vts_init_wrapper(ngx_conf_t *cf);
+
+// Configuration structure
+typedef struct {
+    ngx_flag_t enable;
+    size_t zone_size;
+    ngx_str_t zone_name;
+} ngx_http_vts_loc_conf_t;
+
+// Forward declarations
+static ngx_int_t ngx_http_vts_postconfiguration(ngx_conf_t *cf);
+static void *ngx_http_vts_create_loc_conf(ngx_conf_t *cf);
+static char *ngx_http_vts_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child);
+static char *ngx_http_vts_zone_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+static char *ngx_http_vts_status_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+static char *ngx_http_vts_upstream_stats_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+
+// Handler declaration
+static ngx_int_t ngx_http_vts_status_handler(ngx_http_request_t *r);
+
+// Module commands
+static ngx_command_t ngx_http_vts_commands[] = {
+    {
+        ngx_string("vts_zone"),
+        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE2,
+        ngx_http_vts_zone_directive,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        0,
+        NULL
+    },
+    {
+        ngx_string("vts_status"),
+        NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS,
+        ngx_http_vts_status_directive,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        0,
+        NULL
+    },
+    {
+        ngx_string("vts_upstream_stats"),
+        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG,
+        ngx_http_vts_upstream_stats_directive,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        offsetof(ngx_http_vts_loc_conf_t, enable),
+        NULL
+    },
+    ngx_null_command
+};
+
+// Module context
+static ngx_http_module_t ngx_http_vts_module_ctx = {
+    NULL,                              /* preconfiguration */
+    ngx_http_vts_postconfiguration,    /* postconfiguration */
+    NULL,                              /* create main configuration */
+    NULL,                              /* init main configuration */
+    NULL,                              /* create server configuration */
+    NULL,                              /* merge server configuration */
+    ngx_http_vts_create_loc_conf,      /* create location configuration */
+    ngx_http_vts_merge_loc_conf        /* merge location configuration */
+};
+
+// Module definition
+ngx_module_t ngx_http_vts_module = {
+    NGX_MODULE_V1,
+    &ngx_http_vts_module_ctx,          /* module context */
+    ngx_http_vts_commands,             /* module directives */
+    NGX_HTTP_MODULE,                   /* module type */
+    NULL,                              /* init master */
+    NULL,                              /* init module */
+    NULL,                              /* init process */
+    NULL,                              /* init thread */
+    NULL,                              /* exit thread */
+    NULL,                              /* exit process */
+    NULL,                              /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+// Status handler implementation
+static ngx_int_t
+ngx_http_vts_status_handler(ngx_http_request_t *r)
+{
+    ngx_int_t rc;
+    ngx_buf_t *b;
+    ngx_chain_t out;
+    
+    // Rust function to get status output
+    extern const char* ngx_http_vts_get_status();
+    
+    if (!(r->method & (NGX_HTTP_GET|NGX_HTTP_HEAD))) {
+        return NGX_HTTP_NOT_ALLOWED;
+    }
+    
+    rc = ngx_http_discard_request_body(r);
+    if (rc != NGX_OK) {
+        return rc;
+    }
+    
+    // Get status from Rust implementation
+    const char *status_output = ngx_http_vts_get_status();
+    size_t status_len = ngx_strlen(status_output);
+    
+    // Set response headers
+    r->headers_out.status = NGX_HTTP_OK;
+    r->headers_out.content_length_n = status_len;
+    
+    if (r->method == NGX_HTTP_HEAD) {
+        rc = ngx_http_send_header(r);
+        if (rc == NGX_ERROR || rc > NGX_OK || r->header_only) {
+            return rc;
+        }
+    }
+    
+    // Create response buffer
+    b = ngx_create_temp_buf(r->pool, status_len);
+    if (b == NULL) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+    
+    ngx_memcpy(b->pos, status_output, status_len);
+    b->last = b->pos + status_len;
+    b->last_buf = 1;
+    b->last_in_chain = 1;
+    
+    // Set output chain
+    out.buf = b;
+    out.next = NULL;
+    
+    // Send headers
+    rc = ngx_http_send_header(r);
+    if (rc == NGX_ERROR || rc > NGX_OK || r->header_only) {
+        return rc;
+    }
+    
+    // Send body
+    return ngx_http_output_filter(r, &out);
+}
+
+// Postconfiguration - called after all configuration is parsed
+static ngx_int_t
+ngx_http_vts_postconfiguration(ngx_conf_t *cf)
+{
+    // Initialize the wrapper (includes LOG_PHASE handler registration)
+    return ngx_http_vts_init_wrapper(cf);
+}
+
+// Create location configuration
+static void *
+ngx_http_vts_create_loc_conf(ngx_conf_t *cf)
+{
+    ngx_http_vts_loc_conf_t *conf;
+    
+    conf = ngx_pcalloc(cf->pool, sizeof(ngx_http_vts_loc_conf_t));
+    if (conf == NULL) {
+        return NULL;
+    }
+    
+    conf->enable = NGX_CONF_UNSET;
+    conf->zone_size = NGX_CONF_UNSET_SIZE;
+    
+    return conf;
+}
+
+// Merge location configurations
+static char *
+ngx_http_vts_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
+{
+    ngx_http_vts_loc_conf_t *prev = parent;
+    ngx_http_vts_loc_conf_t *conf = child;
+    
+    ngx_conf_merge_value(conf->enable, prev->enable, 0);
+    ngx_conf_merge_size_value(conf->zone_size, prev->zone_size, 1024*1024);
+    
+    return NGX_CONF_OK;
+}
+
+// Handle vts_zone directive
+static char *
+ngx_http_vts_zone_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    (void)cmd; // Mark as intentionally unused
+    (void)conf; // Mark as intentionally unused
+    (void)cf;  // For now, we don't use the configuration
+    
+    // For now, just accept the directive
+    // The Rust side handles the actual zone setup
+    return NGX_CONF_OK;
+}
+
+// Handle vts_status directive
+static char *
+ngx_http_vts_status_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_core_loc_conf_t *clcf;
+    
+    (void)cmd;  // Mark as intentionally unused
+    (void)conf; // Mark as intentionally unused
+    
+    clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
+    clcf->handler = ngx_http_vts_status_handler;
+    
+    return NGX_CONF_OK;
+}
+
+// Handle vts_upstream_stats directive
+static char *
+ngx_http_vts_upstream_stats_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    (void)cf;   // Mark as intentionally unused
+    (void)cmd;  // Mark as intentionally unused
+    (void)conf; // Mark as intentionally unused
+    
+    // For now, just accept the directive
+    // The LOG_PHASE handler will handle upstream tracking
+    return NGX_CONF_OK;
+}

--- a/src/ngx_vts_wrapper.c
+++ b/src/ngx_vts_wrapper.c
@@ -1,0 +1,185 @@
+/*
+ * nginx VTS module C wrapper for Rust implementation
+ * 
+ * This file provides the necessary C integration to register LOG_PHASE handlers
+ * and bridge nginx requests to the Rust VTS implementation.
+ */
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+// External Rust functions
+extern void vts_track_upstream_request(
+    const char* upstream_name,
+    const char* server_addr,
+    uint64_t request_time,
+    uint64_t upstream_response_time,
+    uint64_t bytes_sent,
+    uint64_t bytes_received,
+    uint16_t status_code
+);
+
+// External Rust initialization function  
+extern ngx_int_t ngx_http_vts_init_rust_module(ngx_conf_t *cf);
+
+/*
+ * LOG_PHASE handler implementation
+ * 
+ * This handler is called by nginx during the LOG_PHASE for each request.
+ * It extracts upstream information and forwards it to the Rust implementation.
+ */
+static ngx_int_t
+ngx_http_vts_log_handler(ngx_http_request_t *r)
+{
+    ngx_http_upstream_t *u;
+    ngx_http_upstream_state_t *state;
+    ngx_str_t upstream_name = ngx_null_string;
+    ngx_str_t server_addr = ngx_null_string; 
+    ngx_msec_t request_time = 0;
+    ngx_msec_t upstream_response_time = 0;
+    off_t bytes_sent = 0;
+    off_t bytes_received = 0;
+    ngx_uint_t status_code = 0;
+    u_char upstream_name_buf[256];
+    u_char server_addr_buf[256];
+
+    // Debug log: LOG_PHASE handler called
+    ngx_log_error(NGX_LOG_NOTICE, r->connection->log, 0,
+                  "VTS LOG_PHASE handler called for request: %V", &r->uri);
+
+    // Only process requests that used upstream
+    u = r->upstream;
+    if (u == NULL) {
+        ngx_log_error(NGX_LOG_NOTICE, r->connection->log, 0,
+                      "VTS LOG_PHASE: No upstream found for request");
+        return NGX_DECLINED;
+    }
+
+    ngx_log_error(NGX_LOG_NOTICE, r->connection->log, 0,
+                  "VTS LOG_PHASE: Found upstream for request");
+
+    // Get upstream name from the upstream configuration
+    if (u->conf && u->conf->upstream) {
+        upstream_name = u->conf->upstream->host;
+    }
+
+    // Extract upstream state information
+    state = u->state;
+    if (state != NULL) {
+        // Get server address
+        if (state->peer) {
+            server_addr = *state->peer;
+        }
+
+        // Get timing information
+        request_time = state->response_time;
+        upstream_response_time = state->response_time; // Simplified
+
+        // Get byte counts
+        bytes_sent = state->bytes_sent;
+        bytes_received = state->bytes_received;
+
+        // Get status code
+        status_code = state->status;
+    }
+
+    // Fallback to request-level information if upstream state is incomplete
+    if (status_code == 0) {
+        status_code = r->headers_out.status;
+    }
+
+    if (request_time == 0 && r->start_sec > 0) {
+        request_time = (ngx_current_msec - r->start_msec);
+    }
+
+    // Convert nginx strings to C strings for Rust FFI
+    if (upstream_name.len > 0 && upstream_name.len < sizeof(upstream_name_buf) - 1) {
+        ngx_memcpy(upstream_name_buf, upstream_name.data, upstream_name.len);
+        upstream_name_buf[upstream_name.len] = '\0';
+    } else {
+        ngx_cpystrn(upstream_name_buf, (u_char*)"default", sizeof(upstream_name_buf));
+    }
+
+    if (server_addr.len > 0 && server_addr.len < sizeof(server_addr_buf) - 1) {
+        ngx_memcpy(server_addr_buf, server_addr.data, server_addr.len);
+        server_addr_buf[server_addr.len] = '\0';
+    } else {
+        ngx_cpystrn(server_addr_buf, (u_char*)"unknown", sizeof(server_addr_buf));
+    }
+
+    // Call Rust function to update statistics
+    ngx_log_error(NGX_LOG_NOTICE, r->connection->log, 0,
+                  "VTS LOG_PHASE: Calling vts_track_upstream_request - upstream: %s, server: %s, status: %d",
+                  upstream_name_buf, server_addr_buf, status_code);
+                  
+    vts_track_upstream_request(
+        (const char*)upstream_name_buf,
+        (const char*)server_addr_buf,
+        (uint64_t)request_time,
+        (uint64_t)upstream_response_time,
+        (uint64_t)bytes_sent,
+        (uint64_t)bytes_received,
+        (uint16_t)status_code
+    );
+    
+    ngx_log_error(NGX_LOG_NOTICE, r->connection->log, 0,
+                  "VTS LOG_PHASE: vts_track_upstream_request completed");
+
+    return NGX_DECLINED;
+}
+
+/*
+ * Register LOG_PHASE handler
+ * 
+ * This function registers the LOG_PHASE handler with nginx.
+ * It should be called during module initialization.
+ */
+ngx_int_t
+ngx_http_vts_register_log_handler(ngx_conf_t *cf)
+{
+    ngx_http_handler_pt *h;
+    ngx_http_core_main_conf_t *cmcf;
+
+    // Get HTTP main configuration
+    cmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module);
+    if (cmcf == NULL) {
+        return NGX_ERROR;
+    }
+
+    // Add handler to LOG_PHASE
+    h = ngx_array_push(&cmcf->phases[NGX_HTTP_LOG_PHASE].handlers);
+    if (h == NULL) {
+        return NGX_ERROR;
+    }
+
+    *h = ngx_http_vts_log_handler;
+
+    return NGX_OK;
+}
+
+/*
+ * Module initialization wrapper
+ * 
+ * This function handles both C-side initialization (LOG_PHASE handler registration)
+ * and Rust-side initialization.
+ */
+ngx_int_t
+ngx_http_vts_init_wrapper(ngx_conf_t *cf)
+{
+    ngx_int_t rc;
+
+    // Register LOG_PHASE handler (C implementation)
+    rc = ngx_http_vts_register_log_handler(cf);
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    // Initialize Rust module
+    rc = ngx_http_vts_init_rust_module(cf);
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    return NGX_OK;
+}


### PR DESCRIPTION
## Summary
- Implements real-time upstream statistics collection through nginx LOG_PHASE handler
- Adds C wrapper components for seamless nginx integration
- Fixes status caching issue preventing live updates
- Resolves ISSUE4.md by enabling real-time upstream zone statistics

## Key Changes
- **New C Components**: Added `src/ngx_vts_wrapper.c` and `src/ngx_http_vts_module.c` for nginx LOG_PHASE handler registration
- **Real-time Updates**: Fixed OnceLock caching issue by implementing Mutex-based dynamic status generation
- **Architecture Enhancement**: Complete LOG_PHASE handler implementation for per-request upstream tracking
- **Documentation**: Updated README with detailed build instructions and architecture documentation

## Test Plan
- [x] Build module with nginx-1.28.0 source
- [x] Configure nginx with upstream backend and VTS module
- [x] Verify LOG_PHASE handler registration in error logs
- [x] Confirm real-time statistics updates via `/status` endpoint
- [x] Test with multiple upstream requests showing live metric changes

## Testing Results
Successfully tested with nginx configuration showing:
- LOG_PHASE handler properly registered and executing per request
- Real-time upstream statistics updates (request counts, timing, status codes)
- Prometheus metrics output with live upstream server data

🤖 Generated with [Claude Code](https://claude.ai/code)